### PR TITLE
feat: Add clickable Security column with ISIN-based external links

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -325,6 +325,9 @@ def get_portfolio_summary(
                 security_symbol = first_transaction.security_symbol if first_transaction else symbol
                 isin = first_transaction.isin if first_transaction else None
                 
+                # Add ISIN to portfolio data for frontend use
+                data["isin"] = isin
+                
                 # Use ISIN-aware price fetching with fallback
                 current_price = get_current_price_with_fallback(symbol=security_symbol, isin=isin)
                 current_value = current_price * data["quantity"]

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -234,9 +234,35 @@ const Dashboard = () => {
                   const pnl = currentValue - stock.total_invested;
                   const pnlPercent = stock.total_invested > 0 ? (pnl / stock.total_invested) * 100 : 0;
 
+                  // Generate external finance link using ISIN if available
+                  const handleSecurityClick = () => {
+                    if (stock.isin) {
+                      // Use Yahoo Finance with ISIN search
+                      const url = `https://finance.yahoo.com/quote/${stock.isin}`;
+                      window.open(url, '_blank', 'noopener,noreferrer');
+                    } else {
+                      // Fallback to Google Finance with security name
+                      const url = `https://www.google.com/finance/quote/${encodeURIComponent(symbol)}`;
+                      window.open(url, '_blank', 'noopener,noreferrer');
+                    }
+                  };
+
                   return (
                     <tr key={symbol}>
-                      <td><strong>{symbol}</strong></td>
+                      <td>
+                        <strong 
+                          style={{ 
+                            cursor: 'pointer', 
+                            color: '#007bff', 
+                            textDecoration: 'none',
+                            borderBottom: '1px dotted #007bff'
+                          }}
+                          onClick={handleSecurityClick}
+                          title={stock.isin ? `Click to view ${symbol} on Yahoo Finance (ISIN: ${stock.isin})` : `Click to view ${symbol} on Google Finance`}
+                        >
+                          {symbol}
+                        </strong>
+                      </td>
                       <td>{stock.quantity}</td>
                       <td>₹{avgPrice.toFixed(2)}</td>
                       <td>₹{currentPrice.toFixed(2)}</td>


### PR DESCRIPTION
Implements enhancement requested in #8

## Summary
- Made Security column clickable in Dashboard current holdings table
- Opens Yahoo Finance using ISIN when available
- Falls back to Google Finance with security name if no ISIN
- Added visual styling and informative tooltips

## Changes
- **Backend**: Modified portfolio endpoint to include ISIN data
- **Frontend**: Added click handler and styling to Security column

## Test Plan
- Verify Security names appear clickable with blue color and dotted underline
- Click securities with ISIN data should open Yahoo Finance
- Click securities without ISIN should open Google Finance
- Tooltips should show destination site and ISIN info

Closes #8

Generated with [Claude Code](https://claude.ai/code)