### PR TITLE
Remove user switching functionality and enforce single-user access

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -442,22 +442,6 @@ def get_transactions(
     
     return query.all()
 
-@app.get("/transactions/all", response_model=List[TransactionResponse])
-def get_all_transactions(
-    security_name: Optional[str] = None,
-    transaction_type: Optional[str] = None,
-    db: Session = Depends(get_db)
-):
-    """Get transactions for all users"""
-    query = db.query(Transaction).join(Security)
-    
-    if security_name:
-        query = query.filter(Security.security_name.ilike(f"%{security_name}%"))
-    
-    if transaction_type:
-        query = query.filter(Transaction.transaction_type == transaction_type)
-    
-    return query.all()
 
 @app.put("/transactions/{transaction_id}", response_model=TransactionResponse)
 def update_transaction(

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,39 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { Navbar as BootstrapNavbar, Nav, Button, NavDropdown } from 'react-bootstrap';
+import React from 'react';
+import { Navbar as BootstrapNavbar, Nav, Button } from 'react-bootstrap';
 import { useAuth } from '../context/AuthContext';
-import { apiService } from '../services/apiService';
 
 const Navbar = () => {
-  const { user, logout, selectedUserId, isAllUsers, switchUser } = useAuth();
-  const [users, setUsers] = useState([]);
-  const [loadingUsers, setLoadingUsers] = useState(false);
-
-  useEffect(() => {
-    loadUsers();
-  }, []);
-
-  const loadUsers = async () => {
-    try {
-      setLoadingUsers(true);
-      const data = await apiService.getUsers();
-      setUsers(data);
-    } catch (error) {
-      console.error('Error loading users:', error);
-    } finally {
-      setLoadingUsers(false);
-    }
-  };
-
-  const getSelectedUserDisplay = () => {
-    if (isAllUsers) {
-      return 'All Users';
-    }
-    if (selectedUserId) {
-      const selectedUser = users.find(u => u.id === selectedUserId);
-      return selectedUser ? selectedUser.username : 'Unknown User';
-    }
-    return user?.username || 'Select User';
-  };
+  const { user, logout } = useAuth();
 
   return (
     <BootstrapNavbar bg="white" expand="lg" className="px-4 shadow-sm">
@@ -42,28 +12,6 @@ const Navbar = () => {
       </BootstrapNavbar.Brand>
       
       <Nav className="ms-auto align-items-center">
-        {/* User Switching Dropdown */}
-        <NavDropdown 
-          title={`👤 ${getSelectedUserDisplay()}`} 
-          id="user-dropdown"
-          className="me-3"
-          disabled={loadingUsers}
-        >
-          <NavDropdown.Item onClick={() => switchUser('all')}>
-            🌐 All Users
-          </NavDropdown.Item>
-          <NavDropdown.Divider />
-          {users.map(u => (
-            <NavDropdown.Item 
-              key={u.id} 
-              onClick={() => switchUser(u.id.toString())}
-              active={selectedUserId === u.id}
-            >
-              👤 {u.username}
-            </NavDropdown.Item>
-          ))}
-        </NavDropdown>
-
         <div className="me-3 d-flex align-items-center">
           {user?.picture_url && (
             <img 

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -16,8 +16,6 @@ export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [selectedUserId, setSelectedUserId] = useState(null);
-  const [isAllUsers, setIsAllUsers] = useState(false);
 
   useEffect(() => {
     const initializeUser = async () => {
@@ -26,7 +24,6 @@ export const AuthProvider = ({ children }) => {
       if (userData) {
         const user = JSON.parse(userData);
         setUser(user);
-        setSelectedUserId(user.id); // Set selectedUserId to current user's ID
         
         // Check admin status if user has email
         if (user.email) {
@@ -64,7 +61,6 @@ export const AuthProvider = ({ children }) => {
       
       localStorage.setItem('user', JSON.stringify(user));
       setUser(user);
-      setSelectedUserId(user.id); // Set selectedUserId to current user's ID
       
       // Check admin status
       if (user.email) {
@@ -94,7 +90,6 @@ export const AuthProvider = ({ children }) => {
       
       localStorage.setItem('user', JSON.stringify(user));
       setUser(user);
-      setSelectedUserId(user.id); // Set selectedUserId to current user's ID
       
       // Check admin status
       if (user.email) {
@@ -115,29 +110,14 @@ export const AuthProvider = ({ children }) => {
     localStorage.removeItem('user');
     setUser(null);
     setIsAdmin(false);
-    setSelectedUserId(null);
-    setIsAllUsers(false);
-  };
-
-  const switchUser = (userId) => {
-    if (userId === 'all') {
-      setIsAllUsers(true);
-      setSelectedUserId(null);
-    } else {
-      setIsAllUsers(false);
-      setSelectedUserId(parseInt(userId));
-    }
   };
 
   const value = {
     user,
     loading,
     isAdmin,
-    selectedUserId,
-    isAllUsers,
     login,
-    logout,
-    switchUser
+    logout
   };
 
   return (

--- a/frontend/src/pages/CapitalGains.js
+++ b/frontend/src/pages/CapitalGains.js
@@ -5,7 +5,7 @@ import { apiService } from '../services/apiService';
 import { toast } from 'react-toastify';
 
 const CapitalGains = () => {
-  const { user, selectedUserId, isAllUsers } = useAuth();
+  const { user } = useAuth();
   const [loading, setLoading] = useState(false);
   const [availableYears, setAvailableYears] = useState([]);
   const [selectedYear, setSelectedYear] = useState('');
@@ -14,18 +14,18 @@ const CapitalGains = () => {
 
   useEffect(() => {
     loadAvailableYears();
-  }, [user, selectedUserId]);
+  }, [user]);
 
   useEffect(() => {
     if (selectedYear) {
       loadCapitalGains();
     }
-  }, [selectedYear, user, selectedUserId]);
+  }, [selectedYear, user]);
 
   const loadAvailableYears = async () => {
     try {
       setLoading(true);
-      const userId = selectedUserId;
+      const userId = user?.id;
       const response = await apiService.getCapitalGainsAvailableYears(userId);
       setAvailableYears(response.available_years || []);
       
@@ -50,7 +50,7 @@ const CapitalGains = () => {
     
     try {
       setLoading(true);
-      const userId = selectedUserId;
+      const userId = user?.id;
       const response = await apiService.getCapitalGains(parseInt(selectedYear), userId);
       setCapitalGains(response);
     } catch (error) {
@@ -149,7 +149,7 @@ const CapitalGains = () => {
                 </Col>
                 <Col md={6}>
                   <p className="text-muted mb-0">
-                    {isAllUsers ? 'Showing data for all users' : `Showing data for selected user`}
+                    {`Showing data for ${user?.username || 'current user'}`}
                   </p>
                 </Col>
               </Row>

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -14,7 +14,7 @@ const Dashboard = () => {
   const [loading, setLoading] = useState(true);
   const [priceData, setPriceData] = useState({});
   const [loadingPrice, setLoadingPrice] = useState({});
-  const { user, selectedUserId, isAllUsers } = useAuth();
+  const { user } = useAuth();
 
   const fetchSecurityPrice = async (symbol, isin) => {
     const securityKey = symbol;
@@ -145,16 +145,16 @@ const Dashboard = () => {
 
   useEffect(() => {
     loadPortfolioData();
-  }, [user, selectedUserId]);
+  }, [user]);
 
   const loadPortfolioData = async () => {
     try {
       setLoading(true);
-      if (!selectedUserId) {
-        toast.error('Please select a user first');
+      if (!user?.id) {
+        toast.error('User not logged in');
         return;
       }
-      const data = await apiService.getPortfolioSummary(selectedUserId);
+      const data = await apiService.getPortfolioSummary(user.id);
       setPortfolio(data);
     } catch (error) {
       toast.error('Unable to load Portfolio Data');

--- a/frontend/src/pages/ManualEntry.js
+++ b/frontend/src/pages/ManualEntry.js
@@ -7,7 +7,7 @@ import { toast } from 'react-toastify';
 import 'react-datepicker/dist/react-datepicker.css';
 
 const ManualEntry = () => {
-  const { user, selectedUserId } = useAuth();
+  const { user } = useAuth();
   const [formData, setFormData] = useState({
     security_name: '',
     security_symbol: '',
@@ -129,7 +129,7 @@ const ManualEntry = () => {
     try {
       const transactionData = {
         ...formData,
-        user_id: selectedUserId,
+        user_id: user?.id,
         quantity: parseFloat(formData.quantity),
         price_per_unit: parseFloat(formData.price_per_unit),
         total_amount: parseFloat(formData.total_amount),

--- a/frontend/src/pages/Transactions.js
+++ b/frontend/src/pages/Transactions.js
@@ -60,11 +60,11 @@ const Transactions = () => {
   const [priceData, setPriceData] = useState({});
   const [loadingPrice, setLoadingPrice] = useState({});
 
-  const { user, selectedUserId, isAllUsers } = useAuth();
+  const { user } = useAuth();
 
   useEffect(() => {
     loadTransactions();
-  }, [user, selectedUserId]);
+  }, [user]);
 
   useEffect(() => {
     applyFilters();
@@ -73,11 +73,11 @@ const Transactions = () => {
   const loadTransactions = async () => {
     try {
       setLoading(true);
-      if (!selectedUserId) {
+      if (!user?.id) {
         toast.error('Please select a user first');
         return;
       }
-      const data = await apiService.getTransactions(selectedUserId);
+      const data = await apiService.getTransactions(user?.id);
       setTransactions(data);
     } catch (error) {
       toast.error('Error loading transactions');
@@ -195,7 +195,7 @@ const Transactions = () => {
         order_date: editingTransaction.order_date.toISOString()
       };
       
-      await apiService.updateTransaction(editingTransaction.id, updatedTransaction, selectedUserId);
+      await apiService.updateTransaction(editingTransaction.id, updatedTransaction, user?.id);
       toast.success('Transaction updated successfully');
       setShowEditModal(false);
       setEditingTransaction(null);
@@ -209,7 +209,7 @@ const Transactions = () => {
   const handleDelete = async (id) => {
     if (window.confirm('Are you sure you want to delete this transaction?')) {
       try {
-        await apiService.deleteTransaction(id, selectedUserId);
+        await apiService.deleteTransaction(id, user?.id);
         toast.success('Transaction deleted successfully');
         loadTransactions();
       } catch (error) {

--- a/frontend/src/pages/Upload.js
+++ b/frontend/src/pages/Upload.js
@@ -16,7 +16,7 @@ const Upload = () => {
   const [editedTransactions, setEditedTransactions] = useState({});
   const [savingChanges, setSavingChanges] = useState(false);
   const [selectedBroker, setSelectedBroker] = useState(DEFAULT_BROKER_ID);
-  const { user, selectedUserId } = useAuth();
+  const { user } = useAuth();
 
   // Memoized broker lookup for performance optimization
   const selectedBrokerData = useMemo(() => 
@@ -71,7 +71,7 @@ const Upload = () => {
 
     setUploading(true);
     try {
-      const result = await apiService.uploadContractNotes(files, password, selectedUserId);
+      const result = await apiService.uploadContractNotes(files, password, user?.id);
       setUploadResults(result);
       setShowPreview(true);
       toast.success(`Successfully processed ${result.uploaded_transactions} transactions`);
@@ -185,7 +185,7 @@ const Upload = () => {
           }
           
           // Call backend API to update the transaction
-          const updatedTransaction = await apiService.updateTransaction(transactionId, updateData, selectedUserId);
+          const updatedTransaction = await apiService.updateTransaction(transactionId, updateData, user?.id);
           
           // Update the local results with the backend response
           updatedResults[transactionIndex] = {


### PR DESCRIPTION
Fixes #35

This PR removes the user switching functionality from the stock portfolio application and enforces single-user access as requested.

## Changes
- Removed user switching dropdown from Navbar
- Updated AuthContext to remove multi-user state management
- Modified all page components to use user.id directly
- Removed backend endpoint that allowed viewing all users' data
- Users can now only access their own data

Generated with [Claude Code](https://claude.ai/code)