### PR TITLE
Remove order_date column from PostgreSQL database and all references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ sqlite3 stock_portfolio.db
 
 ### Core Tables
 - **users**: `id`, `username`, `created_at`
-- **transactions**: `id`, `user_id`, `security_name`, `security_symbol`, `isin`, `transaction_type` (BUY/SELL), `quantity`, `price_per_unit`, `total_amount`, `transaction_date`, `order_date`, `exchange`, `broker_fees`, `taxes`
+- **transactions**: `id`, `user_id`, `security_id`, `transaction_type` (BUY/SELL), `quantity`, `price_per_unit`, `total_amount`, `transaction_date`, `exchange`, `broker_fees`, `taxes`, `created_at`, `updated_at`
 
 ### ISIN Integration
 The system uses International Securities Identification Numbers (ISIN) for accurate stock pricing:

--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -49,6 +49,32 @@ The PostgreSQL database will be automatically created and connected. The FastAPI
 - Automatically create database tables on startup
 - Handle migrations through SQLAlchemy
 
+#### Order Date Column Removal (For Existing Deployments)
+
+If you have an existing Railway deployment that includes the old `order_date` column in the transactions table, you need to run the removal migration:
+
+1. Connect to your Railway project via Railway CLI:
+   ```bash
+   railway login
+   railway link [your-project-id]
+   ```
+
+2. Run the PostgreSQL migration script:
+   ```bash
+   railway run python backend/remove_order_date_postgresql.py
+   ```
+
+3. Or test the connection first:
+   ```bash
+   railway run python backend/remove_order_date_postgresql.py test
+   ```
+
+This migration will:
+- ✅ Remove the redundant `order_date` column from the transactions table
+- ✅ Preserve all other data and columns
+- ✅ Work safely with PostgreSQL (no downtime required)
+- ✅ Auto-verify the migration completed successfully
+
 ### 5. Custom Domains (Optional)
 
 1. Go to your Railway project dashboard

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ Once the backend is running, you can access the interactive API documentation at
 - `price_per_unit`: Price per share
 - `total_amount`: Total transaction amount
 - `transaction_date`: Date of transaction
-- `order_date`: Date of order
 - `exchange`: Stock exchange (NSE, BSE, etc.)
 - `broker_fees`: Brokerage fees
 - `taxes`: Applicable taxes

--- a/backend/migrate_to_postgresql.py
+++ b/backend/migrate_to_postgresql.py
@@ -122,12 +122,11 @@ def migrate_sqlite_to_postgresql():
                     price_per_unit=trans_row[5],
                     total_amount=trans_row[6],
                     transaction_date=datetime.fromisoformat(trans_row[7]) if trans_row[7] else datetime.now(),
-                    order_date=datetime.fromisoformat(trans_row[8]) if trans_row[8] else datetime.now(),
-                    exchange=trans_row[9],
-                    broker_fees=trans_row[10] or 0.0,
-                    taxes=trans_row[11] or 0.0,
-                    created_at=datetime.fromisoformat(trans_row[12]) if trans_row[12] else datetime.now(),
-                    updated_at=datetime.fromisoformat(trans_row[13]) if trans_row[13] else datetime.now()
+                    exchange=trans_row[8],
+                    broker_fees=trans_row[9] or 0.0,
+                    taxes=trans_row[10] or 0.0,
+                    created_at=datetime.fromisoformat(trans_row[11]) if trans_row[11] else datetime.now(),
+                    updated_at=datetime.fromisoformat(trans_row[12]) if trans_row[12] else datetime.now()
                 )
                 pg_session.merge(transaction)
                 migrated_counts["transactions"] += 1

--- a/backend/remove_order_date_postgresql.py
+++ b/backend/remove_order_date_postgresql.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+PostgreSQL migration script to remove the order_date column from transactions table.
+This script is specifically for Railway deployment with PostgreSQL database.
+
+Run this on your Railway PostgreSQL database to remove the redundant order_date column.
+"""
+
+import os
+import sys
+from datetime import datetime
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+def get_postgresql_engine():
+    """Get PostgreSQL engine from DATABASE_URL environment variable"""
+    postgresql_url = os.getenv("DATABASE_URL")
+    if not postgresql_url:
+        print("❌ DATABASE_URL environment variable not set")
+        print("Make sure to set DATABASE_URL to your Railway PostgreSQL connection string")
+        return None
+    
+    # Handle Railway's postgres:// URL format
+    if postgresql_url.startswith("postgres://"):
+        postgresql_url = postgresql_url.replace("postgres://", "postgresql://", 1)
+    
+    try:
+        engine = create_engine(postgresql_url, pool_pre_ping=True)
+        return engine
+    except Exception as e:
+        print(f"❌ Error connecting to PostgreSQL: {e}")
+        return None
+
+def check_order_date_column_exists(engine):
+    """Check if order_date column exists in transactions table"""
+    try:
+        with engine.connect() as conn:
+            # Check if order_date column exists in transactions table
+            result = conn.execute(text("""
+                SELECT column_name 
+                FROM information_schema.columns 
+                WHERE table_name = 'transactions' 
+                AND table_schema = 'public'
+                ORDER BY ordinal_position;
+            """))
+            
+            columns = [row[0] for row in result.fetchall()]
+            order_date_exists = 'order_date' in columns
+            
+            print(f"📋 Checking transactions table schema...")
+            print(f"   Current columns: {columns}")
+            print(f"   order_date column exists: {order_date_exists}")
+            
+            return order_date_exists
+            
+    except Exception as e:
+        print(f"❌ Error checking schema: {e}")
+        return False
+
+def remove_order_date_column(engine):
+    """Remove order_date column from transactions table"""
+    try:
+        with engine.connect() as conn:
+            trans = conn.begin()
+            
+            print("🔧 Starting migration to remove order_date column...")
+            
+            # PostgreSQL supports DROP COLUMN directly
+            conn.execute(text("ALTER TABLE transactions DROP COLUMN IF EXISTS order_date"))
+            
+            # Commit the transaction
+            trans.commit()
+            
+            print("✅ Successfully removed order_date column from transactions table")
+            return True
+            
+    except Exception as e:
+        print(f"❌ Error during migration: {e}")
+        return False
+
+def verify_migration(engine):
+    """Verify that the migration completed successfully"""
+    try:
+        with engine.connect() as conn:
+            # Check new schema
+            result = conn.execute(text("""
+                SELECT column_name 
+                FROM information_schema.columns 
+                WHERE table_name = 'transactions' 
+                AND table_schema = 'public'
+                ORDER BY ordinal_position;
+            """))
+            
+            columns = [row[0] for row in result.fetchall()]
+            
+            # Count transactions to ensure data wasn't lost
+            result = conn.execute(text("SELECT COUNT(*) FROM transactions"))
+            transaction_count = result.fetchone()[0]
+            
+            print("🔍 Verifying migration results...")
+            print(f"   Final columns: {columns}")
+            print(f"   order_date column removed: {'order_date' not in columns}")
+            print(f"   Transaction count: {transaction_count}")
+            
+            # Verify key columns still exist
+            required_columns = [
+                'id', 'user_id', 'security_id', 'transaction_type', 
+                'quantity', 'price_per_unit', 'total_amount', 'transaction_date'
+            ]
+            
+            missing_columns = [col for col in required_columns if col not in columns]
+            
+            if missing_columns:
+                print(f"❌ Missing required columns: {missing_columns}")
+                return False
+            
+            if 'order_date' in columns:
+                print("❌ order_date column still exists!")
+                return False
+                
+            print("✅ Migration verification successful!")
+            return True
+            
+    except Exception as e:
+        print(f"❌ Error during verification: {e}")
+        return False
+
+def test_postgresql_connection():
+    """Test PostgreSQL connection and show database info"""
+    engine = get_postgresql_engine()
+    if not engine:
+        return False
+    
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT version();"))
+            version = result.fetchone()[0]
+            print(f"✅ Connected to PostgreSQL successfully!")
+            print(f"📋 Version: {version}")
+            
+            # Check if transactions table exists
+            result = conn.execute(text("""
+                SELECT table_name 
+                FROM information_schema.tables 
+                WHERE table_schema='public' 
+                AND table_name='transactions';
+            """))
+            
+            has_transactions_table = bool(result.fetchall())
+            print(f"📋 Transactions table exists: {has_transactions_table}")
+            
+            return has_transactions_table
+            
+    except Exception as e:
+        print(f"❌ PostgreSQL connection test failed: {e}")
+        return False
+
+def main():
+    """Main migration function"""
+    print("🚀 PostgreSQL order_date column removal migration")
+    print("=" * 55)
+    
+    # Test connection first
+    if not test_postgresql_connection():
+        print("❌ Cannot connect to PostgreSQL database")
+        print("Make sure DATABASE_URL is set correctly for your Railway PostgreSQL database")
+        sys.exit(1)
+    
+    engine = get_postgresql_engine()
+    
+    # Check if order_date column exists
+    if not check_order_date_column_exists(engine):
+        print("ℹ️  order_date column doesn't exist. Migration not needed.")
+        sys.exit(0)
+    
+    # Confirm migration
+    print("\n⚠️  This will permanently remove the order_date column from the transactions table.")
+    print("   PostgreSQL will automatically handle the column removal safely.")
+    print("✅ Auto-confirming migration (running in automated mode)")
+    
+    # Run migration
+    if remove_order_date_column(engine):
+        if verify_migration(engine):
+            print("\n🎉 Migration completed successfully!")
+            print("\n📝 Next steps:")
+            print("   1. Test your application to ensure everything works")
+            print("   2. Deploy the updated application code")
+            print("   3. Monitor application logs for any issues")
+        else:
+            print("\n❌ Migration completed but verification failed!")
+            print("   Please check your database manually")
+            sys.exit(1)
+    else:
+        print("\n❌ Migration failed!")
+        print("   Please check the error messages above")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "test":
+        print("🔍 Testing PostgreSQL connection...")
+        test_postgresql_connection()
+    else:
+        main()


### PR DESCRIPTION
Fixes #39

This PR removes the order_date column from PostgreSQL database and all its references for Railways deployment.

## Changes Made:
- Fixed migrate_to_postgresql.py to skip order_date column mapping
- Created remove_order_date_postgresql.py for Railway PostgreSQL migrations
- Updated documentation to reflect current database schema
- Added Railway deployment migration instructions

## Testing:
- Verified all order_date references removed from PostgreSQL migration scripts
- Created safe PostgreSQL migration script for existing deployments
- Updated all documentation files

Generated with [Claude Code](https://claude.ai/code)